### PR TITLE
Fixed incorrect usage of event.debugger.set_registers in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ A full example can be found at the end of this section!
         thread_id = event.interrupt.lwpid
         registers = event.interrupt.regs
         registers.rax = 42
-        event.debugger.set_registers(thread_id, registers)
+        await event.debugger.set_registers(thread_id, registers)
         
 
     async with ps4.debugger(pid, resume=True) as debugger:


### PR DESCRIPTION
just a small change in read me, you are meant to await `event.debugger.set_registers ` but in the example its not awaited